### PR TITLE
Prevents a duplicate resource error when a different module is also u…

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,4 @@
 # installs openssl (private)
 class ssl::install {
-  ensure_resource('package', 'openssl', {'ensure' => 'latest' })
+  if ! defined(Package['openssl']) { package { 'openssl': ensure => installed } }
 }


### PR DESCRIPTION
…sing resource Package['openssl']

Uses the method exemplified herehttps://github.com/alup/puppet-rbenv/blob/master/manifests/dependencies/ubuntu.pp#L5

This prevents a duplicate resource error when running `puppet agent -t` when there is another module that uses Package['openssl']